### PR TITLE
Fix period display and countdown logic

### DIFF
--- a/client/src/components/BettingPanel.tsx
+++ b/client/src/components/BettingPanel.tsx
@@ -19,8 +19,8 @@ export default function BettingPanel() {
   const [isPlacingBet, setIsPlacingBet] = useState(false);
   
   const [periodInfo, setPeriodInfo] = useState<PeriodInfo>({
-    current: Date.now(),
-    next: Date.now() + 60000,
+    current: Math.floor(Date.now() / 60000),
+    next: Math.floor(Date.now() / 60000) + 1,
     countdown: 60,
     bettingActive: true
   });
@@ -38,7 +38,7 @@ export default function BettingPanel() {
           newCountdown = 60;
           return {
             current: prev.next,
-            next: prev.next + 60000,
+            next: prev.next + 1,
             countdown: newCountdown,
             bettingActive: true
           };
@@ -148,7 +148,7 @@ export default function BettingPanel() {
     try {
       const response = await api.placeBet({
         username: user.username,
-        period: Math.floor(periodInfo.current / 60000),
+        period: periodInfo.current,
         amount: selectedAmount,
         direction,
         gameType: 'FastParity'
@@ -206,7 +206,7 @@ export default function BettingPanel() {
             <h2 className="text-lg font-semibold text-white mb-1">Current Period</h2>
             <div className="flex items-center space-x-4">
               <span className="text-xl font-bold text-accent-blue">
-                {Math.floor(periodInfo.current / 60000)}
+                {periodInfo.current}
               </span>
               <div className="flex items-center space-x-2">
                 <div className="w-2 h-2 bg-yellow-500 rounded-full animate-pulse"></div>
@@ -220,7 +220,7 @@ export default function BettingPanel() {
           <div className="text-right">
             <div className="text-sm text-gray-400 mb-1">Next Period</div>
             <div className="text-lg font-semibold text-white">
-              {Math.floor(periodInfo.next / 60000)}
+              {periodInfo.next}
             </div>
           </div>
         </div>

--- a/client/src/pages/History.tsx
+++ b/client/src/pages/History.tsx
@@ -25,25 +25,37 @@ export default function History() {
   const [activeTab, setActiveTab] = useState<string>('betting');
 
   // Fetch betting history
-  const { data: bettingHistory = [], isLoading: bettingLoading } = useQuery({
+  const {
+    data: bettingHistory = [],
+    isLoading: bettingLoading,
+  } = useQuery<Bet[]>({
     queryKey: ['/api/bets', user?.username],
     enabled: !!user && activeTab === 'betting',
   });
 
   // Fetch recharge history
-  const { data: rechargeHistory = [], isLoading: rechargeLoading } = useQuery({
+  const {
+    data: rechargeHistory = [],
+    isLoading: rechargeLoading,
+  } = useQuery<Recharge[]>({
     queryKey: ['/api/recharge/history', user?.username],
     enabled: !!user && activeTab === 'recharge',
   });
 
   // Fetch withdrawal history
-  const { data: withdrawalHistory = [], isLoading: withdrawalLoading } = useQuery({
+  const {
+    data: withdrawalHistory = [],
+    isLoading: withdrawalLoading,
+  } = useQuery<Withdrawal[]>({
     queryKey: ['/api/withdraw/history', user?.username],
     enabled: !!user && activeTab === 'withdrawal',
   });
 
   // Fetch transaction history
-  const { data: transactionHistory = [], isLoading: transactionLoading } = useQuery({
+  const {
+    data: transactionHistory = [],
+    isLoading: transactionLoading,
+  } = useQuery<Transaction[]>({
     queryKey: ['/api/transactions', user?.username],
     enabled: !!user && activeTab === 'transactions',
   });

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -183,9 +183,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
         return res.status(404).json({ error: true, message: 'User not found' });
       }
       
-      if (user.balance < amount) {
-        return res.status(400).json({ error: true, message: 'Insufficient balance' });
-      }
+        if ((user.balance ?? 0) < amount) {
+          return res.status(400).json({ error: true, message: 'Insufficient balance' });
+        }
       
       // Convert direction to answer format
       const ans = direction === 'up' ? 'green' : 'red';
@@ -199,7 +199,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       });
       
       // Update user balance
-      await storage.updateUserBalance(username, user.balance - amount);
+        await storage.updateUserBalance(username, (user.balance ?? 0) - amount);
       
       // Create transaction record
       await storage.createTransaction({
@@ -301,14 +301,17 @@ export async function registerRoutes(app: Express): Promise<Server> {
         return res.status(404).json({ error: true, message: 'User not found' });
       }
       
-      if (user.balance < validatedData.amount) {
+      if ((user.balance ?? 0) < validatedData.amount) {
         return res.status(400).json({ error: true, message: 'Insufficient balance' });
       }
       
       const withdrawal = await storage.createWithdrawal(validatedData);
       
       // Update user balance
-      await storage.updateUserBalance(validatedData.username, user.balance - validatedData.amount);
+      await storage.updateUserBalance(
+        validatedData.username,
+        (user.balance ?? 0) - validatedData.amount
+      );
       
       // Create transaction record
       await storage.createTransaction({

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -1,7 +1,7 @@
 import express, { type Express } from "express";
 import fs from "fs";
 import path from "path";
-import { createServer as createViteServer, createLogger } from "vite";
+import { createServer as createViteServer, createLogger, type ServerOptions } from "vite";
 import { type Server } from "http";
 import viteConfig from "../vite.config";
 import { nanoid } from "nanoid";
@@ -20,7 +20,7 @@ export function log(message: string, source = "express") {
 }
 
 export async function setupVite(app: Express, server: Server) {
-  const serverOptions = {
+  const serverOptions: ServerOptions = {
     middlewareMode: true,
     hmr: { server },
     allowedHosts: true,


### PR DESCRIPTION
## Summary
- fix period state to use minute-based value
- correct countdown rollover and API period values
- display current/next period without extra division
- add missing types for history queries
- guard user balance checks and fix Vite server typing

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_684222063e20832282f0f7516d010202